### PR TITLE
Fix Staff rank prefix

### DIFF
--- a/src/main/kotlin/gg/skytils/skytilsmod/utils/Utils.kt
+++ b/src/main/kotlin/gg/skytils/skytilsmod/utils/Utils.kt
@@ -81,7 +81,7 @@ object Utils {
     var dungeons = false
 
     val inDungeons: Boolean
-        get() = dungeons || SBInfo.mode == "dungeon"
+        get() = dungeons || SBInfo.mode == SkyblockIsland.Dungeon.mode
 
     @JvmField
     var isOnHypixel = false
@@ -389,10 +389,7 @@ val gg.skytils.hypixel.types.player.Player.rank_prefix
         "MVP" -> "§b[MVP]"
         "MVP_PLUS" -> "§b[MVP${ChatColor.valueOf(plus_color)}+§b]"
         "MVP_PLUS_PLUS" -> "${ChatColor.valueOf(mvp_plus_plus_color)}[MVP${ChatColor.valueOf(plus_color)}++${ChatColor.valueOf(mvp_plus_plus_color)}]"
-        "HELPER" -> "§9[HELPER]"
-        "MODERATOR" -> "§2[MOD]"
-        "GAME_MASTER" -> "§2[GM]"
-        "ADMIN" -> "§c[ADMIN]"
+        "STAFF" -> "§c[§6ዞ§c]"
         "YOUTUBER" -> "§c[§fYOUTUBE§c]"
         else -> "§7"
     }


### PR DESCRIPTION
Fixes Staff rank prefix showing as default rank color due to the else section of §7 after a recent change that unified all management ranks into one STAFF rank (see https://hypixel.net/threads/team-update-one-unified-rank.5628609/).

This does remove the other ranks. Helper already got removed long ago IIRC, then all mods got changed to GM a while ago, and now there's no GM or ADMIN either, just STAFF.

Tested in-game and it works.

**Note**: In the future, the else section might want an extra warning logged for unknown rank and an explicit match/check for default rank (no idea what string API returns for default rank, needs debugging), but I did not want to touch that part of the code in this PR.